### PR TITLE
Test PR From a external Fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Bazel Build](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml)
 [![Validation](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml)
 [![Docker Container](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml)
- 
+  
   
 * [Getting started](#getting-started)
    * [Installing packaged versions of P4C](#installing-packaged-versions-of-p4c)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Validation](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml)
 [![Docker Container](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml)
  
-
+ 
 * [Getting started](#getting-started)
    * [Installing packaged versions of P4C](#installing-packaged-versions-of-p4c)
    * [Installing P4C from source](#installing-p4c-from-source)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Bazel Build](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml)
 [![Validation](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml)
 [![Docker Container](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml)
-
+ 
 
 * [Getting started](#getting-started)
    * [Installing packaged versions of P4C](#installing-packaged-versions-of-p4c)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Bazel Build](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-bazel.yml)
 [![Validation](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml)
 [![Docker Container](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml)
-  
+   
   
 * [Getting started](#getting-started)
    * [Installing packaged versions of P4C](#installing-packaged-versions-of-p4c)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Validation](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-validation-nightly.yml)
 [![Docker Container](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml/badge.svg)](https://github.com/p4lang/p4c/actions/workflows/ci-container-image.yml)
  
- 
+  
 * [Getting started](#getting-started)
    * [Installing packaged versions of P4C](#installing-packaged-versions-of-p4c)
    * [Installing P4C from source](#installing-p4c-from-source)


### PR DESCRIPTION
## Failing to preview webpage from external Forks  

To handle comments on pull requests from forks in GitHub Actions, you need to address the limitations related to the permissions of the GitHub token (GITHUB_TOKEN). When a workflow runs on a pull request from a forked repository, the default GITHUB_TOKEN has read-only permissions, which prevents it from commenting on issues or pull requests.

To overcome this, you can use a personal access token (PAT) with the necessary permissions instead of the default GITHUB_TOKEN.

Here's how you can update your workflow to use a PAT:

Create a Personal Access Token (PAT):

- Go to your GitHub account settings.
- Navigate to "Developer settings" and then to "Personal access tokens."
- Generate a new token with repo and workflow permissions.
- Store the PAT in GitHub Secrets:

Go to your repository settings.

- Navigate to "Secrets and variables" -> "Actions."
- Add a new secret named PAT_TOKEN and paste the PAT you created.
- Update your workflow to use the PAT:

```bash 

  - name: Comment on PR
    uses: hasura/comment-progress@v2.2.0
    if: github.event_name == 'pull_request'
    with:
      github-token: ${{ secrets.PAT_TOKEN }}
      repository: ${{ github.repository }}
      number: ${{ github.event.number }}
      id: deploy-preview
      message: " **🚀 Deployment of preview started...**"
```